### PR TITLE
V0.13.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# meili-crates
-Push every crates to meili
+# Meili Crates
+
+A [new experience of search](https://crates.meilisearch.com) to find your favorite crates 🎉
+
+**Search by crate name or by keywords.**
+
+[![crates demo gif](assets/crates-io-demo.gif)](https://crates.meilisearch.com)
+
+The search is powered by [MeiliSearch](https://github.com/meilisearch/MeiliSearch), the open-source and instant search engine.
+
+## See also
+
+- MeiliSearch finds [PyPI packages](https://pypi.meilisearch.com/) (Python)
+- MeiliSearch finds [RubyGems](https://rubygems.meilisearch.com/) (Ruby)
+
+## How to run the data collector
+
+Set the following envrionment variables:
+- `MEILI_HOST_URL`
+- `MEILI_API_KEY`
+- `MEILI_INDEX_UID` (it should set to `crates` to be used with the front of this repo)
+
+```bash
+$ ./run.sh
+```
+
+## Details
+
+The front is deployed to GitHub Pages.
+
+We pull new crates and crates updates every 10 minutes from [docs.rs](https://docs.rs/releases) and all the downloads counts every day at 3:30 PM UTC from [crates.io](https://crates.io/data-access).
+
+Here is the [repository of MeiliSearch](https://github.com/meilisearch/MeiliSearch).

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ cargo build --release
 
 git clone --depth=1 https://github.com/rust-lang/crates.io-index.git
 
-cp ./target/release/init /usr/local/bin/init-meili-crates
+cp ./target/release/full_init /usr/local/bin/init-meili-crates
 cp ./target/release/live /usr/local/bin/live-meili-crates
 
 /usr/local/bin/init-meili-crates

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ pub async fn chunk_complete_crates_info_to_meili(
 
     let client = HttpClient::new()?;
 
-    let mut receiver = receiver.chunks(150);
+    let mut receiver = receiver.chunks(100);
     while let Some(chunk) = StreamExt::next(&mut receiver).await {
         let url = format!("{host_url}/indexes/{index_uid}/documents",
             host_url = host_url,


### PR DESCRIPTION
I updated the droplet of [crates.meilisearch.com](https://crates.meilisearch.com/) from MeiliSearch v0.11.0 (or v0.10.0, I don't remember) to v0.13.0.
So:
- I resized the documents chunkw because I got some `413 Request Entity Too Large` by NginX
- I fixed the `run.sh` and updated the README, because I never remember how to re-populate the DB 😂